### PR TITLE
feat: encapsulating main method

### DIFF
--- a/cmd/api/gateway/gateway.go
+++ b/cmd/api/gateway/gateway.go
@@ -1,12 +1,107 @@
 package gateway
 
-import "github.com/gin-gonic/gin"
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
 
-func NewGateway(group *gin.RouterGroup) {
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gin-gonic/gin"
+	"github.com/venture-technology/venture/config"
+	"github.com/venture-technology/venture/internal/handler"
+	"github.com/venture-technology/venture/internal/repository"
+	"github.com/venture-technology/venture/internal/usecase/responsible"
+
+	_ "github.com/lib/pq"
+)
+
+func SetHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Header("charset", "utf-8")
+		c.Next()
+	}
+}
+
+type Gateway struct {
+	router   *gin.Engine
+	group    *gin.RouterGroup
+	database *sql.DB
+	cloud    *session.Session
+}
+
+func NewGateway(router *gin.Engine, group *gin.RouterGroup) *Gateway {
+	return &Gateway{
+		router: router,
+		group:  group,
+	}
+}
+
+func (g *Gateway) Setup() {
+
+	config, err := config.Load("../../config/config.yaml")
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	db, err := sql.Open("postgres", postgres(config.Database))
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+
+	g.database = db
+
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(config.Cloud.Region),
+		Credentials: credentials.NewStaticCredentials(config.Cloud.AccessKey, config.Cloud.SecretKey, config.Cloud.Token),
+	})
+	if err != nil {
+		log.Fatalf("failed to create session at aws: %v", err)
+	}
+
+	g.cloud = sess
+
+	err = migrate(g.database, config.Database.Schema)
+	if err != nil {
+		log.Fatalf("failed to execute migrations: %v", err)
+	}
+
+	g.Responsible()
+
+	g.router.Run(fmt.Sprintf(":%d", config.Server.Port))
 
 }
 
-func ConfigureHeaders(c *gin.Context) {
-	c.Header("Content-Type", "application/json; charset=utf-8")
-	c.Header("charset", "utf-8")
+func (g *Gateway) Responsible() {
+	handler := handler.NewResponsibleHandler(responsible.NewResponsibleUseCase(repository.NewResponsibleRepository(g.database)))
+	g.group.POST("/responsible", handler.Create)
+	g.group.GET("/responsible", handler.Get)
+	g.group.PATCH("/responsible", handler.Update)
+	g.group.DELETE("/responsible", handler.Delete)
+}
+
+func postgres(dbconfig config.Database) string {
+	return "user=" + dbconfig.User +
+		" password=" + dbconfig.Password +
+		" dbname=" + dbconfig.Name +
+		" host=" + dbconfig.Host +
+		" port=" + dbconfig.Port +
+		" sslmode=disable"
+}
+
+func migrate(db *sql.DB, filepath string) error {
+	schema, err := os.ReadFile(filepath)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(string(schema))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,1 +1,18 @@
 package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/venture-technology/venture/cmd/api/gateway"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+
+	r := gin.Default()
+
+	v1 := r.Group("api/v1")
+	v1.Use(gateway.SetHeaders())
+	gateway.NewGateway(r, v1).Setup()
+
+}

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
+	github.com/lib/pq v1.10.9
 	github.com/segmentio/kafka-go v0.4.47
-	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/stripe/stripe-go/v79 v79.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZY
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -75,8 +77,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPrP7KZm1gPFQquJQvM=
-github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stripe/stripe-go/v79 v79.7.0 h1:6oRLRWVvkDObiiSLc0PJZz5zxyMIRj/f9dqs9dn1LB4=
 github.com/stripe/stripe-go/v79 v79.7.0/go.mod h1:cuH6X0zC8peY6f1AubHwgJ/fJSn2dh5pfiCr6CjyKVU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=


### PR DESCRIPTION
# Encapsulando o método main

Basicamente, antes tínhamos um código muito sujo no main, cheio de inicializações. Isso não necessariamente era um problema de fato, mas era sujo. Era estranho pra identificar o que era o que ou o que realmente era feito. 

Um exemplo de um dos nossos microserviços legados.
![image](https://github.com/user-attachments/assets/282d83bd-aa4e-4d48-9ced-292b535d05fb)

Agora de maneira bem mais simples. Encapsulei todas inicializações, podíamos usar alguma injeção de dependência mas para o nosso nível de maturidade com código `Go`, não faz tanto sentido.
> Abaixo nosso main atual
![image](https://github.com/user-attachments/assets/31435af9-6736-488f-85ec-bdd6f44bf5d9)
