### PR TITLE
transactions seats car

### DIFF
--- a/database/migrations/20250416114133_add-version-to-seats.down.sql
+++ b/database/migrations/20250416114133_add-version-to-seats.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE drivers DROP COLUMN seats_version;
+
+COMMIT;

--- a/database/migrations/20250416114133_add-version-to-seats.up.sql
+++ b/database/migrations/20250416114133_add-version-to-seats.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE drivers ADD COLUMN seats_version BIGINT NOT NULL DEFAULT 0;
+
+COMMIT;

--- a/database/structure.sql
+++ b/database/structure.sql
@@ -146,11 +146,13 @@ CREATE TABLE public.drivers (
     seats_morning integer,
     seats_afternoon integer,
     seats_night integer,
-    states character varying(100) DEFAULT ''::character varying,
-    city character varying(100) DEFAULT ''::character varying,
+    state character varying(100) DEFAULT ''::character varying NOT NULL,
+    city character varying(100) DEFAULT ''::character varying NOT NULL,
     accessibility boolean DEFAULT false,
     biography character varying(1000) DEFAULT ''::character varying,
-    descriptions character varying(550) DEFAULT ''::character varying
+    descriptions character varying(550) DEFAULT ''::character varying,
+    neighborhood character varying(255) DEFAULT ''::character varying NOT NULL,
+    seats_version bigint DEFAULT 0 NOT NULL
 );
 
 
@@ -353,8 +355,9 @@ CREATE TABLE public.responsibles (
     profile_image text DEFAULT 'null'::text,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    states character varying(100) DEFAULT ''::character varying,
-    city character varying(100) DEFAULT ''::character varying
+    state character varying(100) DEFAULT ''::character varying NOT NULL,
+    city character varying(100) DEFAULT ''::character varying NOT NULL,
+    neighborhood character varying(255) DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -434,8 +437,9 @@ CREATE TABLE public.schools (
     profile_image text DEFAULT 'null'::text,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    states character varying(100) DEFAULT ''::character varying,
-    city character varying(100) DEFAULT ''::character varying
+    state character varying(100) DEFAULT ''::character varying NOT NULL,
+    city character varying(100) DEFAULT ''::character varying NOT NULL,
+    neighborhood character varying(255) DEFAULT ''::character varying NOT NULL
 );
 
 

--- a/internal/entity/driver.go
+++ b/internal/entity/driver.go
@@ -37,14 +37,15 @@ type Driver struct {
 type Car struct {
 	Name     string `gorm:"column:car_name" json:"name,omitempty" validate:"required"`
 	Year     string `gorm:"column:car_year" json:"year,omitempty" validate:"required"`
-	Capacity int64  `gorm:"column:car_capacity" json:"capacity,omitempty" validate:"required"`
+	Capacity uint   `gorm:"column:car_capacity" json:"capacity,omitempty" validate:"required"`
 }
 
 type Seats struct {
-	Remaining int64 `gorm:"column:seats_remaining" json:"remaining,omitempty"`
-	Morning   int64 `gorm:"column:seats_morning" json:"morning,omitempty"`
-	Afternoon int64 `gorm:"column:seats_afternoon" json:"afternoon,omitempty"`
-	Night     int64 `gorm:"column:seats_night" json:"night,omitempty"`
+	Remaining uint  `gorm:"column:seats_remaining" json:"remaining,omitempty"`
+	Morning   uint  `gorm:"column:seats_morning" json:"morning,omitempty"`
+	Afternoon uint  `gorm:"column:seats_afternoon" json:"afternoon,omitempty"`
+	Night     uint  `gorm:"column:seats_night" json:"night,omitempty"`
+	Version   int64 `gorm:"column:seats_version" json:"version,omitempty"`
 }
 
 type ClaimsDriver struct {

--- a/internal/entity/driver.go
+++ b/internal/entity/driver.go
@@ -79,3 +79,15 @@ func (d *Driver) ValidateLogin() error {
 
 	return nil
 }
+
+func (d *Driver) ValidateCapacity() error {
+	if d.Car.Capacity < 30 {
+		return fmt.Errorf("capacity must be greater than 30")
+	}
+
+	if d.Car.Capacity > 300 {
+		return fmt.Errorf("capacity must be less than 300")
+	}
+
+	return nil
+}

--- a/internal/infra/persistence/contract_repository.go
+++ b/internal/infra/persistence/contract_repository.go
@@ -61,9 +61,16 @@ func (cr ContractRepositoryImpl) Accept(contract *entity.Contract) error {
 				"seats_morning":   driver.Seats.Morning - 1,
 				"seats_version":   driver.Seats.Version + 1,
 			}
-			return tx.Model(&entity.Driver{}).
+			result := tx.Model(&entity.Driver{}).
 				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
-				UpdateColumns(attributes).Error
+				UpdateColumns(attributes)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				return fmt.Errorf("seats_version mismatch: possible concurrent update")
+			}
+			return nil
 		},
 		value.AfternoonShift: func(driver entity.Driver) error {
 			if driver.Seats.Afternoon <= 0 {
@@ -75,9 +82,16 @@ func (cr ContractRepositoryImpl) Accept(contract *entity.Contract) error {
 				"seats_afternoon": driver.Seats.Afternoon - 1,
 				"seats_version":   driver.Seats.Version + 1,
 			}
-			return tx.Model(&entity.Driver{}).
+			result := tx.Model(&entity.Driver{}).
 				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
-				UpdateColumns(attributes).Error
+				UpdateColumns(attributes)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				return fmt.Errorf("seats_version mismatch: possible concurrent update")
+			}
+			return nil
 		},
 		value.NightShift: func(driver entity.Driver) error {
 			if driver.Seats.Night <= 0 {
@@ -89,9 +103,16 @@ func (cr ContractRepositoryImpl) Accept(contract *entity.Contract) error {
 				"seats_night":     driver.Seats.Night - 1,
 				"seats_version":   driver.Seats.Version + 1,
 			}
-			return tx.Model(&entity.Driver{}).
+			result := tx.Model(&entity.Driver{}).
 				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
-				UpdateColumns(attributes).Error
+				UpdateColumns(attributes)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				return fmt.Errorf("seats_version mismatch: possible concurrent update")
+			}
+			return nil
 		},
 	}
 

--- a/internal/infra/persistence/contract_repository.go
+++ b/internal/infra/persistence/contract_repository.go
@@ -44,33 +44,53 @@ func (cr ContractRepositoryImpl) Accept(contract *entity.Contract) error {
 		return err
 	}
 
-	// update of driver's seats
+	// valida seats > 0
+	if driver.Seats.Remaining <= 0 {
+		return fmt.Errorf("driver %s has no remaining seats", driver.CNH)
+	}
+
+	// update de acordo com o turno
 	createSeats := map[string]func(driver entity.Driver) error{
 		value.MorningShift: func(driver entity.Driver) error {
-			attributes := make(map[string]interface{})
-			attributes["updated_at"] = realtime.Now().UTC()
-			attributes["seats_remaining"] = driver.Seats.Remaining - 1
-			attributes["seats_morning"] = driver.Seats.Morning - 1
+			if driver.Seats.Morning <= 0 {
+				return fmt.Errorf("no morning seats available for driver %s", driver.CNH)
+			}
+			attributes := map[string]interface{}{
+				"updated_at":      realtime.Now().UTC(),
+				"seats_remaining": driver.Seats.Remaining - 1,
+				"seats_morning":   driver.Seats.Morning - 1,
+				"seats_version":   driver.Seats.Version + 1,
+			}
 			return tx.Model(&entity.Driver{}).
-				Where("cnh = ?", contract.DriverCNH).
+				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
 				UpdateColumns(attributes).Error
 		},
 		value.AfternoonShift: func(driver entity.Driver) error {
-			attributes := make(map[string]interface{})
-			attributes["updated_at"] = realtime.Now().UTC()
-			attributes["seats_remaining"] = driver.Seats.Remaining - 1
-			attributes["seats_afternoon"] = driver.Seats.Afternoon - 1
+			if driver.Seats.Afternoon <= 0 {
+				return fmt.Errorf("no afternoon seats available for driver %s", driver.CNH)
+			}
+			attributes := map[string]interface{}{
+				"updated_at":      realtime.Now().UTC(),
+				"seats_remaining": driver.Seats.Remaining - 1,
+				"seats_afternoon": driver.Seats.Afternoon - 1,
+				"seats_version":   driver.Seats.Version + 1,
+			}
 			return tx.Model(&entity.Driver{}).
-				Where("cnh = ?", contract.DriverCNH).
+				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
 				UpdateColumns(attributes).Error
 		},
 		value.NightShift: func(driver entity.Driver) error {
-			attributes := make(map[string]interface{})
-			attributes["updated_at"] = realtime.Now().UTC()
-			attributes["seats_remaining"] = driver.Seats.Remaining - 1
-			attributes["seats_night"] = driver.Seats.Night - 1
+			if driver.Seats.Night <= 0 {
+				return fmt.Errorf("no night seats available for driver %s", driver.CNH)
+			}
+			attributes := map[string]interface{}{
+				"updated_at":      realtime.Now().UTC(),
+				"seats_remaining": driver.Seats.Remaining - 1,
+				"seats_night":     driver.Seats.Night - 1,
+				"seats_version":   driver.Seats.Version + 1,
+			}
 			return tx.Model(&entity.Driver{}).
-				Where("cnh = ?", contract.DriverCNH).
+				Where("cnh = ? AND seats_version = ?", contract.DriverCNH, driver.Seats.Version).
 				UpdateColumns(attributes).Error
 		},
 	}

--- a/internal/usecase/create_driver_usecase.go
+++ b/internal/usecase/create_driver_usecase.go
@@ -34,6 +34,11 @@ func (cduc *CreateDriverUseCase) CreateDriver(driver *entity.Driver) error {
 		return err
 	}
 
+	err = driver.ValidateCapacity()
+	if err != nil {
+		return err
+	}
+
 	driver, err = fillSeatCapacity(driver)
 	if err != nil {
 		return fmt.Errorf("error filling seat capacity: %w", err)


### PR DESCRIPTION
<!--- De extrema importância que você detalhe o máximo possível. -->

## Descrição
<!--- Descreva com detalhes sua mudança -->
essa é uma das prs mais interessantes do venture

- adicionamos uso de transaction para o accept
- a validação de capacity para ser obrigatório maior que 30 e menor que 300
- mudamos o tipo int64 para uint para evitar que as seats sejam negativas
- estamos adicionando tratamento de concorrência sobre as seats

#### como assim?

imagine que o motorista tenha apenas 2 assentos disponíveis e que por acaso três responsáveis tentaram comprar por esses assentos restantes, hoje sem essa pr o que aconteceria é as seats ficaram com -1 negativos

> isso não pode mais acontecer alterando o tipo dela pra uint

entao, adicionamos a coluna de seats_version, imagine que ela seja 0 e tenha dois assentos restante, por latencia ou algo assim, algum dos três responsáveis sairá na frente e os assentos restantes cairão pra 1 e seats_version subirá pra 1

agora supondo que os outros dois tentaram comprar aquele mesmo assento, se a version for diferente de quando buscaram ela no inicio da request, essa tentativa de compra falha e quebra a transaction.

## Motivação e Contexto
<!--- Porque sua mudança foi necessária? O que ela resolve? -->
<!--- Se você está tratando um card em especifíco, cole ele aqui -->
#206
#198
#208
#193

## Como ela pode ser testada?
<!--- Por favor, escreva com detalhes como você fez pra testar -->
<!--- Inclua os detalhes locais e os de ambiente -->
<!--- Veja como sua mudança afeta outras áreas, ou algo similar -->

1. crie um contrato e valide subindo o numero da seats_version e a queda do seats_remaining
