### PR TITLE
feat: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22.5-alpine AS builder
+FROM golang:1.24.2-alpine AS builder
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux


### PR DESCRIPTION
<!--- De extrema importância que você detalhe o máximo possível. -->

## Descrição
<!--- Descreva com detalhes sua mudança -->
deploy está quebrando visto que a versão do go necessária é 1.23, mas estamos com 1.22. Por padrão, atualizei pra stable 1.24.2