### PR TITLE
sqs implementing

### DIFF
--- a/internal/infra/contracts/contracts.go
+++ b/internal/infra/contracts/contracts.go
@@ -5,24 +5,34 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"github.com/venture-technology/venture/internal/entity"
+	"github.com/venture-technology/venture/internal/value"
 	"go.uber.org/zap"
 )
 
+// Interace to communicate with S3 Bucket Services.
 type S3Iface interface {
 	// Save a file like png, to more performance
 	Save(bucket, path, filename string, file []byte) (string, error)
+
+	// List files in a bucket
 	List(bucket, path string) ([]string, error)
+
 	// Save a file like anytype file
 	SaveWithType(bucket, path, filaneme string, file []byte, contentType string) (string, error)
 
-	// types to return
-
+	// Save file like html
 	HTML() string
+
+	// Save file like pdf
 	PDF() string
+
+	// Save file like png
 	PNG() string
 }
 
+// Interface to use Simple Email Service
 type SESIface interface {
+	// SendEmail send email to user
 	SendEmail(email *entity.Email) error
 }
 
@@ -31,6 +41,7 @@ type PostgresIface interface {
 	Close() error
 }
 
+// Interface to use Redis
 type Cacher interface {
 	Set(key string, value any, expiration time.Duration) error
 	Get(key string) (string, error)
@@ -42,6 +53,19 @@ type Logger interface {
 	Errorf(format string, args ...zap.Field)
 }
 
+// Interface to convert files
 type Converters interface {
 	ConvertPDFtoHTML(htmlFile []byte, contractProperty entity.ContractProperty) ([]byte, error)
+}
+
+// Interface to use Simple Queue Service
+type Queue interface {
+	// Send message to queue
+	SendMessage(queue, message string) error
+
+	// Gets the messages from the queue, need the CreateMessage format.
+	PullMessages(queue string) ([]value.CreateMessage, error)
+
+	// Delete a specific message of queue by identifier
+	DeleteMessage(queue, identifier string) error
 }

--- a/internal/infra/email/ses.go
+++ b/internal/infra/email/ses.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SesImpl struct {
-	sess *session.Session
+	ses *ses.SES
 }
 
 func NewSesImpl() *SesImpl {
@@ -29,13 +29,11 @@ func NewSesImpl() *SesImpl {
 	}
 
 	return &SesImpl{
-		sess: sess,
+		ses: ses.New(sess),
 	}
 }
 
 func (sesImpl *SesImpl) SendEmail(email *entity.Email) error {
-	svc := ses.New(sesImpl.sess)
-
 	emailInput := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			ToAddresses: []*string{aws.String(email.Recipient)},
@@ -53,7 +51,7 @@ func (sesImpl *SesImpl) SendEmail(email *entity.Email) error {
 		Source: aws.String(viper.GetString("AWS_SES_EMAIL_FROM")),
 	}
 
-	_, err := svc.SendEmail(emailInput)
+	_, err := sesImpl.ses.SendEmail(emailInput)
 
 	if err != nil {
 		return err

--- a/internal/infra/queue/sqs.go
+++ b/internal/infra/queue/sqs.go
@@ -1,0 +1,109 @@
+package queue
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/spf13/viper"
+	"github.com/venture-technology/venture/internal/value"
+)
+
+const (
+	BatchSize         = 10
+	VisibilityTimeout = 30
+	WaitSeconds       = 10
+)
+
+type SQSImpl struct {
+	Client *sqs.SQS
+}
+
+func NewSQSQueue() SQSImpl {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(viper.GetString("AWS_REGION")),
+		Credentials: credentials.NewStaticCredentials(
+			viper.GetString("AWS_ACCESS_KEY"),
+			viper.GetString("AWS_SECRET_KEY"),
+			viper.GetString("AWS_TOKEN"),
+		),
+	})
+	if err != nil {
+		log.Fatalf("failed to create session at aws: %v", err)
+	}
+
+	return SQSImpl{
+		Client: sqs.New(sess),
+	}
+}
+
+func (s SQSImpl) SendMessage(queue, message string) error {
+	sendMessageInput := &sqs.SendMessageInput{
+		MessageBody: aws.String(message),
+		QueueUrl:    aws.String(queue),
+	}
+
+	_, err := s.Client.SendMessage(sendMessageInput)
+	if err != nil {
+		log.Printf("sqs - failed to send message to queue: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (s SQSImpl) PullMessages(queue string) ([]*value.CreateMessage, error) {
+	msgOutput, err := s.Client.ReceiveMessage(&sqs.ReceiveMessageInput{
+		AttributeNames: []*string{
+			aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
+		},
+		MessageAttributeNames: []*string{
+			aws.String(sqs.QueueAttributeNameAll),
+		},
+		QueueUrl:            &queue,
+		MaxNumberOfMessages: aws.Int64(BatchSize),
+		VisibilityTimeout:   aws.Int64(VisibilityTimeout),
+		WaitTimeSeconds:     aws.Int64(WaitSeconds),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sqs - failed to receive message from queue: %v", err)
+	}
+
+	totalMessages := len(msgOutput.Messages)
+	messages := make([]*value.CreateMessage, 0, totalMessages)
+	msg := make(chan *value.CreateMessage)
+
+	for _, rawMessage := range msgOutput.Messages {
+		go func(queue *string, rawMessage *sqs.Message, msg chan<- *value.CreateMessage) {
+			msg <- &value.CreateMessage{
+				QueueURL:      *queue,
+				ReceiptHandle: *rawMessage.ReceiptHandle,
+				Body:          *rawMessage.Body,
+			}
+		}(&queue, rawMessage, msg)
+	}
+
+	for i := 0; i < totalMessages; i++ {
+		messages = append(messages, <-msg)
+	}
+
+	close(msg)
+	return messages, nil
+}
+
+func (s SQSImpl) DeleteMessage(queue, identifier string) error {
+	_, err := s.Client.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      &queue,
+		ReceiptHandle: &identifier,
+	})
+
+	if err != nil {
+		log.Printf("sqs - failed to delete message from queue: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/value/service.go
+++ b/internal/value/service.go
@@ -408,3 +408,9 @@ type CreateSchool struct {
 	CreatedAt    time.Time `json:"created_at,omitempty"`
 	UpdatedAt    time.Time `json:"updated_at,omitempty"`
 }
+
+type CreateMessage struct {
+	QueueURL      string
+	ReceiptHandle string
+	Body          string
+}


### PR DESCRIPTION
<!--- De extrema importância que você detalhe o máximo possível. -->

## Descrição
<!--- Descreva com detalhes sua mudança -->
- implementação do sqs para enviar, receber e deletar mensagens do sqs, com isso também conto a implementação do contrato
- comentários para documentar funções no arquivo de `contracts.go`
- alteração da maneira como criamos sessões da aws para uma ferramenta

> explicação:
anteriormente, realizavamos a criação assim, exemplo com S3 e sua implementação.
```go
type S3Impl struct {
	sess *session.Session
}

func NewS3Impl() *S3Impl {
	sess, err := session.NewSession(&aws.Config{
		Region: aws.String(viper.GetString("AWS_REGION")),
		Credentials: credentials.NewStaticCredentials(
			viper.GetString("AWS_ACCESS_KEY"),
			viper.GetString("AWS_SECRET_KEY"),
			viper.GetString("AWS_TOKEN"),
		),
	})
	if err != nil {
		log.Fatalf("failed to create session at aws: %v", err)
	}

	return &S3Impl{
		sess: sess,
	}
}
```

assim, criamos uma nova sessão, entretanto não uma nova sessão com a ferramenta do S3, então em toda função do S3, tinhamos que colocar a linha
```go
svc := s3.New(s3Impl.sess)
```

Então, agora é assim. Implementando a sessão com a ferramenta diretamente
```go

type S3Impl struct {
	bucket *s3.S3
}

func NewS3Impl() *S3Impl {
	sess, err := session.NewSession(&aws.Config{
		Region: aws.String(viper.GetString("AWS_REGION")),
		Credentials: credentials.NewStaticCredentials(
			viper.GetString("AWS_ACCESS_KEY"),
			viper.GetString("AWS_SECRET_KEY"),
			viper.GetString("AWS_TOKEN"),
		),
	})
	if err != nil {
		log.Fatalf("failed to create session at aws: %v", err)
	}

	return &S3Impl{
		bucket: s3.New(sess),
	}
}
```
> Sem a necessidade de usar aquela linha, alteramos isso para o S3 e SES, claro, SQS

## Motivação e Contexto
<!--- Porque sua mudança foi necessária? O que ela resolve? -->
<!--- Se você está tratando um card em especifíco, cole ele aqui -->
#297 