### PR TITLE
feat: improve call file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/spf13/viper"
-	"github.com/venture-technology/venture/pkg/stringcommon"
 	"github.com/venture-technology/venture/pkg/utils"
 )
 
@@ -16,7 +15,7 @@ const (
 )
 
 func LoadServerEnvironmentVars(service, serverEnv string) error {
-	if stringcommon.Empty(serverEnv) || serverEnv == "development" {
+	if serverEnv == "development" {
 		viper.SetDefault(ServerEnvironment, "development")
 	}
 
@@ -24,12 +23,12 @@ func LoadServerEnvironmentVars(service, serverEnv string) error {
 		viper.SetConfigType("json")
 		viper.SetConfigName(viper.GetString(ServerEnvironment)) // development
 
-		projectRoot, err := utils.FindGoModRoot()
+		path, err := utils.GetAbsPath()
 		if err != nil {
 			return err
 		}
 
-		viper.AddConfigPath(filepath.Join(projectRoot, "config"))
+		viper.AddConfigPath(path)
 
 		if err := viper.ReadInConfig(); err != nil {
 			fmt.Println("Failed to read config file:", err)

--- a/internal/usecase/create_contract_usecase.go
+++ b/internal/usecase/create_contract_usecase.go
@@ -158,10 +158,14 @@ func (ccuc *CreateContractUseCase) SetContractProperty(
 }
 
 func getHtmlPath() (string, error) {
-	root, err := utils.FindGoModRoot()
+	path, err := utils.GetAbsPath()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(root, value.GetPathHTML()), nil
+	return filepath.Join(path, pathAgreement()), nil
+}
+
+func pathAgreement() string {
+	return "../domain/service/agreements/template/agreement.html"
 }

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -1,28 +1,15 @@
 package utils
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
+	"runtime"
 )
 
-func FindGoModRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
+var (
+	_, b, _, _ = runtime.Caller(0)
+	basepath   = filepath.Dir(b)
+)
 
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-
-	return "", fmt.Errorf("go.mod not found")
+func GetAbsPath() (string, error) {
+	return basepath, nil
 }

--- a/pkg/utils/root_test.go
+++ b/pkg/utils/root_test.go
@@ -1,72 +1,16 @@
 package utils
 
 import (
-	"os"
-	"path/filepath"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestFindGoModRoot(t *testing.T) {
-	t.Run("encontra go.mod no diretório atual", func(t *testing.T) {
-		tmp := t.TempDir()
-
-		goModPath := filepath.Join(tmp, "go.mod")
-		err := os.WriteFile(goModPath, []byte("module test"), 0644)
-		if err != nil {
-			t.Fatalf("falha ao criar go.mod: %v", err)
-		}
-
-		originalWD, _ := os.Getwd()
-		defer os.Chdir(originalWD)
-		os.Chdir(tmp)
-
-		root, err := FindGoModRoot()
-		if err != nil {
-			t.Fatalf("esperava encontrar go.mod, mas deu erro: %v", err)
-		}
-		if root != tmp {
-			t.Errorf("esperado %s, mas obteve %s", tmp, root)
-		}
-	})
-
-	t.Run("encontra go.mod em um diretório pai", func(t *testing.T) {
-		tmp := t.TempDir()
-
-		subdir := filepath.Join(tmp, "a", "b", "c")
-		err := os.MkdirAll(subdir, 0755)
-		if err != nil {
-			t.Fatalf("falha ao criar subdiretórios: %v", err)
-		}
-
-		goModPath := filepath.Join(tmp, "go.mod")
-		err = os.WriteFile(goModPath, []byte("module test"), 0644)
-		if err != nil {
-			t.Fatalf("falha ao criar go.mod: %v", err)
-		}
-
-		originalWD, _ := os.Getwd()
-		defer os.Chdir(originalWD)
-		os.Chdir(subdir)
-
-		root, err := FindGoModRoot()
-		if err != nil {
-			t.Fatalf("esperava encontrar go.mod, mas deu erro: %v", err)
-		}
-		if root != tmp {
-			t.Errorf("esperado %s, mas obteve %s", tmp, root)
-		}
-	})
-
-	t.Run("retorna erro quando go.mod não é encontrado", func(t *testing.T) {
-		tmp := t.TempDir()
-
-		originalWD, _ := os.Getwd()
-		defer os.Chdir(originalWD)
-		os.Chdir(tmp)
-
-		_, err := FindGoModRoot()
-		if err == nil {
-			t.Fatal("esperava erro ao não encontrar go.mod, mas não ocorreu erro")
-		}
+func TestGetAbsPath(t *testing.T) {
+	t.Run("encontra basepath", func(t *testing.T) {
+		absPath, err := GetAbsPath()
+		fmt.Println(absPath)
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!--- De extrema importância que você detalhe o máximo possível. -->

## Descrição
<!--- Descreva com detalhes sua mudança -->
- alterei a maneira que lidamos com as chamadas de arquivo, para chamar a nível de sistema operacional usando o runtime do go.

a função de `runtime.Caller(0)`, verifica o arquivo em que ela é chamada e retorna o path completo na stack 0.
exemplo:
> se o `main.go` chama o `usecasetest.go`
a funcao de chamar path está no `usecasetest.go`, entao o `runtime.Caller` vai retornar `usecasetest.go` no path, mas se no arquivo de `usecasetest.go` a função utilizada for `runtime.Caller(1)`, ele vai chamar o nível de cima da pilha, nesse caso seria quem chamou ele, o `main.go`

- em conjunto, removi a opção que caso não tivesse variavel definida no sistema operacional como `ENVIRONMENT` ele automaticamente transformava development, no ambiente.

ambas trocas foram feitas, visando o uso de lambdas.